### PR TITLE
IGLOO-18636 - Reformatted text is not being highlighted in yellow like it is in prod

### DIFF
--- a/src/HtmlDiff/HtmlDiff.cs
+++ b/src/HtmlDiff/HtmlDiff.cs
@@ -30,11 +30,12 @@ namespace HtmlDiff
             {"</sub>",0},
             {"</sup>",0},
             {"</strike>",0},
-            {"</s>",0}
+            {"</s>",0},
+            {"</span>",0}
         };
 
         private static readonly Regex SpecialCaseOpeningTagRegex = new Regex(
-            "<((strong)|(b)|(i)|(em)|(big)|(small)|(u)|(sub)|(sup)|(strike)|(s))[\\>\\s]+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            "<((strong)|(b)|(i)|(em)|(big)|(small)|(u)|(sub)|(sup)|(strike)|(s)|(span))[\\>\\s]+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
 
         /// <summary>


### PR DESCRIPTION
### What's changed:
- Added span tag to dictionary so it can be picked up and highlight font size and text color changes (since they are added with span tags).

### How to test it:
- Clone this forked repo
- Open the `HtmlDiff.sln` in VS and build it.
- In any core branch, remove the `HtmlDiff` reference from `Igloo.Old.Common` and replace it with the .dll file found in `C:\htmldiff.net\src\HtmlDiff\bin\Debug\net45`.
- Build the branch.
- Go to a wiki article, edit it
    - Change font sizes or text colours and verify that these changes will be highlighted.
    - Change other things to make sure everything is still working normally.

https://igloojira.atlassian.net/browse/IGLOO-18636 